### PR TITLE
fix ensemble change.

### DIFF
--- a/BookKeeperProtocol.tla
+++ b/BookKeeperProtocol.tla
@@ -483,7 +483,7 @@ ChangeEnsemble(c, recovery) ==
         /\ failed_bookies # {}
         /\ \A bookie \in failed_bookies : WriteTimeoutForBookie(messages, c.id, bookie, recovery)
         /\ LET first_entry_id == c.lac + 1
-               good_bookies   == c.curr_fragment.ensemble \ failed_bookies
+               good_bookies == c.curr_fragment.ensemble \ failed_bookies
            IN
               /\ EnsembleAvailable(good_bookies, failed_bookies)
               /\ \A bookie \in good_bookies : ~WriteTimeoutForBookie(messages, c.id, bookie, recovery)

--- a/BookKeeperProtocol.tla
+++ b/BookKeeperProtocol.tla
@@ -480,11 +480,14 @@ ChangeEnsemble(c, recovery) ==
     /\ \/ recovery
        \/ ~recovery /\ c.meta_version = meta_version
     /\ \E failed_bookies \in SUBSET c.curr_fragment.ensemble :
+        /\ failed_bookies # {}
         /\ \A bookie \in failed_bookies : WriteTimeoutForBookie(messages, c.id, bookie, recovery)
-        /\ EnsembleAvailable(c.curr_fragment.ensemble \ failed_bookies, failed_bookies)
         /\ LET first_entry_id == c.lac + 1
+               good_bookies   == c.curr_fragment.ensemble \ failed_bookies
            IN
-              /\ LET new_ensemble   == SelectEnsemble(c.curr_fragment.ensemble \ failed_bookies, failed_bookies)
+              /\ EnsembleAvailable(good_bookies, failed_bookies)
+              /\ \A bookie \in good_bookies : ~WriteTimeoutForBookie(messages, c.id, bookie, recovery)
+              /\ LET new_ensemble   == SelectEnsemble(good_bookies, failed_bookies)
                      updated_fragments == UpdatedFragments(c, first_entry_id, new_ensemble)
                  IN
                     \* only update the metadata if not in ledger recovery


### PR DESCRIPTION
There are some bugs with the precondition of ensemble change.
The `failed_bookies` selected can't gurantee that all failed bookies are included as we don't check whether there are any bookie is WriteTimeout in `c.curr_fragment.ensemble \ failed_bookies`.
What is worse, a empty set could be assign to `failed_bookies`, which means we trigger the ensemble change without any bookie fail.